### PR TITLE
fix(cv2_tesseract): graceful skip when tesseract binary absent (#11)

### DIFF
--- a/pd_book_tools/ocr/cv2_tesseract.py
+++ b/pd_book_tools/ocr/cv2_tesseract.py
@@ -9,10 +9,13 @@ from pd_book_tools.ocr.page import Page
 try:
     from pytesseract import Output as pytesseract_Output
     from pytesseract import image_to_data, image_to_string
+
+    _pytesseract_available = True
 except ImportError:
-    raise ImportError(
-        "pytesseract is not installed. Please install extra dependency [tesseract]"
-    )
+    _pytesseract_available = False
+    pytesseract_Output = None
+    image_to_data = None
+    image_to_string = None
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,11 @@ def tesseract_ocr_cv2_image(
             provenance records (L-18). Defaults to ``"eng"`` to preserve
             historical behavior.
     """
+    if not _pytesseract_available:
+        raise ImportError(
+            "pytesseract is not installed. Please install extra dependency [tesseract]"
+        )
+
     if image.ndim == 2:
         # If the image is already grayscale, no need to convert
         image_grayscale = image

--- a/tests/ocr/test_cv2_tesseract.py
+++ b/tests/ocr/test_cv2_tesseract.py
@@ -1,5 +1,7 @@
 """Tests for cv2_tesseract OCR adapter module."""
 
+import importlib.util
+import shutil
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -11,6 +13,10 @@ from cv2 import imread
 from pd_book_tools.ocr.cv2_tesseract import tesseract_ocr_cv2_image
 from pd_book_tools.ocr.document import Document
 from pd_book_tools.ocr.page import Page
+
+# Check if pytesseract is available for integration tests
+_pytesseract_available = importlib.util.find_spec("pytesseract") is not None
+_tesseract_binary_available = shutil.which("tesseract") is not None
 
 
 class TestTesseractOcrCv2Image:
@@ -478,6 +484,10 @@ class TestImportError:
         assert "Please install extra dependency [tesseract]" in content
 
 
+@pytest.mark.skipif(
+    not (_pytesseract_available and _tesseract_binary_available),
+    reason="pytesseract not installed or tesseract binary not found in PATH (required for real image integration tests)",
+)
 class TestRealImageIntegration:
     """Integration tests with real images (requires pytesseract)."""
 
@@ -486,15 +496,8 @@ class TestRealImageIntegration:
         """Path to the test image."""
         return Path(__file__).parent.parent / "ocr-test-image.png"
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("pytesseract", reason="pytesseract not available"),
-        reason="Requires pytesseract for integration testing",
-    )
     def test_real_image_ocr(self, test_image_path):
         """Test OCR with real test image."""
-        pytest.importorskip("cv2")
-        pytest.importorskip("pytesseract")
-
         # Load the test image
         image = imread(str(test_image_path))
         assert image is not None, f"Could not load test image: {test_image_path}"
@@ -511,15 +514,8 @@ class TestRealImageIntegration:
         # We don't assert specific text since OCR results can vary
         assert hasattr(result_page, "items")
 
-    @pytest.mark.skipif(
-        not pytest.importorskip("pytesseract", reason="pytesseract not available"),
-        reason="Requires pytesseract for integration testing",
-    )
     def test_real_image_grayscale_vs_color(self, test_image_path):
         """Test that grayscale and color versions of same image produce similar results."""
-        pytest.importorskip("cv2")
-        pytest.importorskip("pytesseract")
-
         from cv2 import IMREAD_COLOR, IMREAD_GRAYSCALE, imread
 
         # Load as grayscale and color

--- a/tests/ocr/test_cv2_tesseract.py
+++ b/tests/ocr/test_cv2_tesseract.py
@@ -483,6 +483,19 @@ class TestImportError:
         assert "pytesseract is not installed" in content
         assert "Please install extra dependency [tesseract]" in content
 
+    def test_tesseract_ocr_without_pytesseract_raises_clear_error(self):
+        """When pytesseract is not available, calling tesseract_ocr_cv2_image
+        raises a clear ImportError with helpful guidance."""
+        import numpy as np
+
+        with patch("pd_book_tools.ocr.cv2_tesseract._pytesseract_available", False):
+            image = np.zeros((10, 10), dtype=np.uint8)
+            with pytest.raises(
+                ImportError,
+                match=r"pytesseract is not installed.*Please install extra dependency \[tesseract\]",
+            ):
+                tesseract_ocr_cv2_image(image)
+
 
 @pytest.mark.skipif(
     not (_pytesseract_available and _tesseract_binary_available),


### PR DESCRIPTION
## Summary

Recovers a TDD slice for issue #11 (`cv2_tesseract` real-image integration: graceful skip when the tesseract binary is absent).

The slice consists of two commits originally produced by `/ship-issue` earlier today:

1. `TestRealImageIntegration` skips cleanly when `pytesseract` / the tesseract binary is unavailable.
2. New test verifying a clear error message when `tesseract_ocr` is called without `pytesseract` installed.

## Why this is a manual recovery PR

The bot's `wip/ship-issue` branch was reset by `ship-issue-failure.sh` after `make ci` reported a failure — but the failure was a flaky parallel-pytest race in `tests/ocr/test_reorganize_page_utils_grouping.py` under `pytest -n auto`, **unrelated to this slice**. The slice itself was correct; targeted `make test-k K=test_cv2_tesseract` passes (17/17) and `make lint` is clean.

The flaky `reorganize_page_utils` test will be filed as a separate `kind:bug` issue.

Cherry-picked from reflog commits `bf790f1` and `3b69cdd` onto current `origin/master` (`57eeeda`); resulting tree byte-identical to the bot's original output.

## Test plan

- [x] `make test-k K=test_cv2_tesseract` — 17 passed
- [x] `make lint` — clean
- [ ] CI on PR (the unrelated flaky test in `reorganize_page_utils` may still bounce; a re-run should clear it)

Closes #11