### PR TITLE
fix(test): per-worker current/diff subdirs to close xdist rmtree race

### DIFF
--- a/tests/ocr/test_reorganize_page_utils_grouping.py
+++ b/tests/ocr/test_reorganize_page_utils_grouping.py
@@ -17,8 +17,15 @@ from pd_book_tools.ocr.word import Word
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "layout_regression"
 INPUT_DIR = FIXTURE_ROOT / "inputs"
 TEXT_BASELINE_DIR = FIXTURE_ROOT / "expected_text" / "baseline"
-TEXT_CURRENT_DIR = FIXTURE_ROOT / "expected_text" / "current"
-TEXT_DIFF_DIR = FIXTURE_ROOT / "expected_text" / "diff"
+_TEXT_CURRENT_ROOT = FIXTURE_ROOT / "expected_text" / "current"
+_TEXT_DIFF_ROOT = FIXTURE_ROOT / "expected_text" / "diff"
+# Per-worker subtree under each output root so xdist workers don't race on
+# the session-scoped rmtree (issue #14). When running serially (no xdist),
+# ``PYTEST_XDIST_WORKER`` is unset and the suffix is empty — output lands
+# directly under the canonical root, preserving legacy behaviour.
+_WORKER_ID = os.environ.get("PYTEST_XDIST_WORKER", "")
+TEXT_CURRENT_DIR = _TEXT_CURRENT_ROOT / _WORKER_ID if _WORKER_ID else _TEXT_CURRENT_ROOT
+TEXT_DIFF_DIR = _TEXT_DIFF_ROOT / _WORKER_ID if _WORKER_ID else _TEXT_DIFF_ROOT
 # Debug PNGs / text reports land under a per-run timestamped subfolder so old
 # runs accumulate and can be diffed across changes. The whole tree is
 # gitignored — `rm -rf debug/` to reclaim disk.
@@ -173,10 +180,17 @@ def _wipe_text_outputs():
     wiped here; ``run_dir`` gives each session its own subfolder so old
     runs are preserved.
 
-    ``ignore_errors=True`` makes this safe under ``pytest -n auto``:
-    multiple xdist workers each enter this session-scoped fixture and
-    race on the rmtree. We don't care which worker wins — only that the
-    dirs are gone before tests start writing into them.
+    Under ``pytest -n auto`` (xdist) each worker process runs its own
+    copy of this session-scoped fixture. To avoid a TOCTOU race where
+    worker A's session-start rmtree fires *after* worker B has already
+    mkdir'd ``TEXT_CURRENT_DIR`` and is about to ``write_text`` into it
+    (issue #14), each worker scopes its writes to a per-worker subtree
+    (``current/<worker_id>/...``) and only wipes its own subtree here.
+    Sequential runs (no xdist) keep the legacy behaviour: wipe the
+    canonical root.
+
+    ``ignore_errors=True`` keeps the wipe safe even if the dir is
+    already absent (first run after a clean checkout).
     """
     import shutil
 


### PR DESCRIPTION
## Summary

Closes #14.

`test_reorganize_page_expected_text_outputs` flaked under `pytest -n auto` with `FileNotFoundError` while writing `current/<case>.reorganize.txt`. The parent dir disappeared between the test's per-test `mkdir(parents=True, exist_ok=True)` and the subsequent `write_text` call.

## Root cause

The module had a session-scoped autouse fixture (`_wipe_text_outputs`) that did `shutil.rmtree(TEXT_CURRENT_DIR, ignore_errors=True)` at session start, where `TEXT_CURRENT_DIR` was a shared module-level path. Under `pytest-xdist`, each worker runs its own session-scoped setup, so worker A's session-start rmtree could fire **after** worker B had already entered a parametrized test, mkdir'd the dir, and was about to write into it. The window is small but nonzero — exactly consistent with the observed one-off flake on `plate-chairs-beauvais-tapestry`.

Diagnosis matches the issue body's "fix path 1" (per-worker output dirs) — closely related to the existing pattern in `_new_run_dir` for `DEBUG_DIR` (lines 137–148).

## Fix (path a from the issue body)

Scope each xdist worker's writes to a per-worker subtree by folding `PYTEST_XDIST_WORKER` into `TEXT_CURRENT_DIR` and `TEXT_DIFF_DIR`:

- Under xdist: `current/<gwN>/<case>.reorganize.txt` — each worker's session-start rmtree only nukes its own subtree, so cross-worker races become impossible by construction.
- Sequential (no xdist, `PYTEST_XDIST_WORKER` unset): writes go directly under the canonical root — legacy layout preserved.

The reads from these dirs are write-only artifacts for human debugging — the actual assertion compares an in-memory string against the baseline file — so per-worker isolation is safe.

## Why path (a) and not (b) or serialize?

- Path (a) is one well-localized change to two module-level constants + the existing rmtree. Sequential behaviour is unchanged.
- Path (b) (skip rmtree under xdist) leaves stale data from a prior xdist run in workers' subtrees on the next run.
- `xdist_group` requires `--dist loadgroup` and bottlenecks the slowest single test on one worker.

## Verification

- `uv run pytest -n auto -k test_reorganize_page_expected_text_outputs` x5 consecutive runs: 26 passed + 5 xfailed each time. Race did not reproduce.
- Sequential `uv run pytest -k ...`: 26 passed + 5 xfailed; canonical layout (`current/<case>.reorganize.txt`) preserved.
- Confirmed per-worker subdirs (`gw0..gw13`) are created under xdist.
- `make lint`: clean.

## Test plan

- [ ] CI green on this branch.
- [ ] Spot-check that no test still references the bare `current/` path expecting non-worker-scoped layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)