### PR TITLE
feat: add PEP 561 py.typed marker (v0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ GitHub Releases (with attached wheel + sdist) are at
 
 ---
 
+## [v0.14.0] — 2026-05-22
+
+- **PEP 561 `py.typed` marker** — downstream consumers no longer require
+  `# pyright: ignore[reportMissingTypeStubs]` on `from pd_book_tools...`
+  imports. Part of workspace-wide `reportMissingTypeStubs` cleanup.
+
+---
+
 ## [v0.13.0] — 2026-05-22
 
 ### Added


### PR DESCRIPTION
Adds empty pd_book_tools/py.typed PEP 561 marker so downstream consumers no longer need pyright: ignore[reportMissingTypeStubs] on pd_book_tools imports. Phase 0 of workspace-wide reportMissingTypeStubs cleanup. make ci passes.