### PR TITLE
fix: fall back to typing_extensions.override on Python 3.11 (v0.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ GitHub Releases (with attached wheel + sdist) are at
 
 ---
 
+## [v0.14.1] — 2026-05-23
+
+- **Python 3.11 compat** — `typing.override` import now falls back to
+  `typing_extensions.override` on Python < 3.12 (`typing.override` was
+  added in 3.12; importing it bare caused `ImportError` for any downstream
+  package running on 3.11).
+
+---
+
 ## [v0.14.0] — 2026-05-22
 
 - **PEP 561 `py.typed` marker** — downstream consumers no longer require

--- a/pd_book_tools/geometry/bounding_box.py
+++ b/pd_book_tools/geometry/bounding_box.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import functools
+import sys
 from dataclasses import dataclass
 from logging import getLogger
-from typing import TYPE_CHECKING, TypedDict, TypeVar, override
+from typing import TYPE_CHECKING, TypedDict, TypeVar
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override  # pyright: ignore[reportUnreachable]
 
 from pydantic_core import CoreSchema, core_schema
 from shapely.geometry import (

--- a/pd_book_tools/geometry/point.py
+++ b/pd_book_tools/geometry/point.py
@@ -1,4 +1,10 @@
-from typing import cast, override
+import sys
+from typing import cast
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override  # pyright: ignore[reportUnreachable]
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema

--- a/pd_book_tools/hf/download.py
+++ b/pd_book_tools/hf/download.py
@@ -18,8 +18,13 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import sys
 from pathlib import Path, PurePosixPath
-from typing import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override  # pyright: ignore[reportUnreachable]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_bounding_box_py311_compat.py
+++ b/tests/test_bounding_box_py311_compat.py
@@ -1,0 +1,25 @@
+"""Regression test for Python 3.11 compat: bounding_box.py must import cleanly
+on Python < 3.12 (typing.override was added in 3.12; we fall back to
+typing_extensions.override on older interpreters).
+
+This test exercises the import path that triggered the ImportError in
+pd-ocr-ops when it bumped to pd-book-tools v0.14.0 on Python 3.11.
+"""
+
+from pd_book_tools.geometry.bounding_box import BoundingBox
+from pd_book_tools.geometry.point import Point
+
+
+def test_bounding_box_importable_on_all_python_versions():
+    """BoundingBox can be imported and instantiated regardless of Python version."""
+    bb = BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0))
+    assert bb.minX == 0.0
+    assert bb.minY == 0.0
+    assert bb.maxX == 1.0
+    assert bb.maxY == 1.0
+
+
+def test_bounding_box_repr_uses_override():
+    """@override decorator on __repr__ must work on Python 3.11 and 3.12+."""
+    bb = BoundingBox(Point(0.1, 0.2), Point(0.8, 0.9))
+    assert repr(bb) == "BoundingBox.from_ltrb(0.1, 0.2, 0.8, 0.9)"


### PR DESCRIPTION
## Summary

- `typing.override` was added in Python 3.12; three source files imported it bare, causing `ImportError` on Python 3.11 for any downstream that runs on 3.11 (e.g. `pd-ocr-ops` PR #79).
- Applied `sys.version_info >= (3, 12)` guard in `bounding_box.py`, `point.py`, and `hf/download.py` — falls back to `typing_extensions.override` on older interpreters.
- `typing_extensions` is already a transitive dependency (via pydantic, torch, etc.) so no `pyproject.toml` change is needed.
- Adds `tests/test_bounding_box_py311_compat.py` regression test.

**Paradox resolution:** pd-book-tools CI runs on Python 3.13 only (single-version matrix in `.github/workflows/ci.yml`), so the bare `typing.override` import went undetected until pd-ocr-ops tried to use v0.14.0 on 3.11.

## Test plan

- [x] `uv run --python 3.11 python -c "from pd_book_tools.geometry.bounding_box import BoundingBox"` — passes after fix
- [x] New regression test passes on 3.11 venv
- [x] `make ci AI=1` green on 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)