### PR TITLE
fix(types): clear 7 basedpyright warnings unbreaking main

### DIFF
--- a/pd_book_tools/image_processing/cupy_processing/_cupy_compat.py
+++ b/pd_book_tools/image_processing/cupy_processing/_cupy_compat.py
@@ -32,7 +32,7 @@ GPU_EXTRA_INSTALL_HINT = (
 # lets the module load on CPU-only installs; require_cupy() in every GPU
 # function raises the actionable ImportError before cp is ever dereferenced.
 try:
-    import cupy as cp  # pyright: ignore[reportMissingImports, reportMissingTypeStubs]  # CuPy is an optional GPU dep (not in lockfile); ships without usable stubs.
+    import cupy as cp  # pyright: ignore[reportMissingImports]  # CuPy is an optional GPU dep (not in lockfile).
 
     _CUPY_AVAILABLE = True
     _CUPY_IMPORT_ERROR: ImportError | None = None

--- a/pd_book_tools/image_processing/cupy_processing/colors.py
+++ b/pd_book_tools/image_processing/cupy_processing/colors.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
+
 from ._cupy_compat import cp, require_cupy
 
 if TYPE_CHECKING:
-    import numpy as np
     import numpy.typing as npt
 
     CuPyArray = npt.NDArray[np.generic]
@@ -32,7 +33,7 @@ def _bgr2gray_weights() -> CuPyArray:
         require_cupy()
         _bgr2gray_weights_cache = cast(
             "CuPyArray",
-            cp.array([0.114, 0.587, 0.299], dtype=cp.float32),
+            cp.array([0.114, 0.587, 0.299], dtype=np.float32),
         )
     return _bgr2gray_weights_cache
 
@@ -47,14 +48,14 @@ def bgr_to_gray_gpu(img_cp: CuPyArray) -> CuPyArray:
     """
     require_cupy()
     weights = _bgr2gray_weights()
-    float_img = cast("CuPyArray", img_cp.astype(cp.float32))
+    float_img = cast("CuPyArray", img_cp.astype(np.float32))
     gray = cast(
         "CuPyArray",
         weights[0] * float_img[:, :, 0]
         + weights[1] * float_img[:, :, 1]
         + weights[2] * float_img[:, :, 2],
     )
-    return cast("CuPyArray", gray.clip(0, 255).astype(cp.uint8))
+    return cast("CuPyArray", gray.clip(0, 255).astype(np.uint8))
 
 
 def gray_to_bgr_gpu(img_cp: CuPyArray) -> CuPyArray:

--- a/pd_book_tools/image_processing/cupy_processing/filters.py
+++ b/pd_book_tools/image_processing/cupy_processing/filters.py
@@ -9,10 +9,11 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
+
 from ._cupy_compat import cp, require_cupy
 
 if TYPE_CHECKING:
-    import numpy as np
     import numpy.typing as npt
 
     CuPyArray = npt.NDArray[np.generic]
@@ -58,7 +59,7 @@ def gaussian_filter_gpu(
     _sigma = (sigma, sigma, 0) if img_cp.ndim == 3 else sigma
 
     result = gaussian_filter_fn(
-        cast("CuPyArray", img_cp.astype(cp.float32)),
+        cast("CuPyArray", img_cp.astype(np.float32)),
         sigma=_sigma,
     )  # pyright: ignore[reportOptionalCall]  # guarded by require_cupy()
     return cast("CuPyArray", cp.rint(result).clip(0, 255).astype(img_cp.dtype))
@@ -101,7 +102,7 @@ def uniform_filter_gpu(
     _size = (size, size, 1) if img_cp.ndim == 3 else size
 
     result = uniform_filter_fn(
-        cast("CuPyArray", img_cp.astype(cp.float32)),
+        cast("CuPyArray", img_cp.astype(np.float32)),
         size=_size,
     )  # pyright: ignore[reportOptionalCall]  # guarded by require_cupy()
     return cast("CuPyArray", cp.rint(result).clip(0, 255).astype(img_cp.dtype))

--- a/pd_book_tools/image_processing/cupy_processing/rescale.py
+++ b/pd_book_tools/image_processing/cupy_processing/rescale.py
@@ -76,7 +76,7 @@ def rescale_image_gpu(
 
     logger.debug("rescale_image_gpu: %sx%s -> %sx%s", height, width, new_h, new_w)
 
-    src = cast("CuPyArray", img_cp.astype(cp.float32))
+    src = cast("CuPyArray", img_cp.astype(np.float32))
 
     # Anti-alias before subsampling. Bare bilinear (order=1) zoom aliases on
     # high-frequency content when zoom_factor < 1; cv2 sidesteps this with
@@ -99,7 +99,7 @@ def rescale_image_gpu(
 
     zoom_factors = (zoom_h, zoom_w) if img_cp.ndim == 2 else (zoom_h, zoom_w, 1.0)
     result = zoom_fn(src, zoom_factors, order=1)  # pyright: ignore[reportOptionalCall]  # guarded by require_cupy() in caller
-    return cast("CuPyArray", result.clip(0, 255).astype(cp.uint8))
+    return cast("CuPyArray", result.clip(0, 255).astype(np.uint8))
 
 
 def np_uint8_rescale_image(


### PR DESCRIPTION
## Summary
- Main has been RED on CI since 15bb4b7 cleared the basedpyright baseline without fixing the underlying 7 warnings. failOnWarnings=true gates CI.
- Root cause: CuPy ships no usable stubs, so `cp.float32` / `cp.uint8` resolve to `Any` and flow into `.astype(dtype=...)` as `reportUnknownArgumentType`. CuPy accepts numpy dtypes interchangeably; switching to `np.float32` / `np.uint8` gives basedpyright a fully-typed argument with identical runtime behavior.
- Also drops a redundant `reportMissingTypeStubs` ignore in `_cupy_compat.py`.

Follows the workspace fix-don't-suppress rule (CONVENTIONS.md). Baseline.json stays empty.

## Warnings cleared (7)
- `_cupy_compat.py:35` `reportUnnecessaryTypeIgnoreComment` → removed the now-redundant `reportMissingTypeStubs` from the ignore list
- `colors.py:50,57` `reportUnknownArgumentType` → `np.float32` / `np.uint8`
- `filters.py:61,104` `reportUnknownArgumentType` → `np.float32`
- `rescale.py:79,102` `reportUnknownArgumentType` → `np.float32` / `np.uint8`

## Test plan
- [x] `uv run basedpyright pd_book_tools` → 0 errors, 0 warnings
- [x] `make ci AI=1` green locally
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)